### PR TITLE
Give more information on which PO file is being edited.

### DIFF
--- a/tpl/admin-poedit.tpl.php
+++ b/tpl/admin-poedit.tpl.php
@@ -46,9 +46,9 @@ $modified or $pofiles[] = $path;
                     $url = LocoAdmin::edit_uri( $package, $_path );
                 ?> 
                 <option value="<?php Loco::h($url)?>" <?php $poname === $label and print('selected')?>>
-                    <?php Loco::h($label); 
-					if (strpos($_path, DIRECTORY_SEPARATOR . 'wp-content' . DIRECTORY_SEPARATOR . 'languages' . DIRECTORY_SEPARATOR ) !== false) echo " (override)";
-					else echo " (official)"; ?>  
+                    <?php Loco::h($label);
+		          if (strpos($_path, DIRECTORY_SEPARATOR . 'wp-content' . DIRECTORY_SEPARATOR . 'languages' . DIRECTORY_SEPARATOR ) !== false || 0 === strpos($_path, 'languages' . DIRECTORY_SEPARATOR)) echo " (user)";
+			  else echo " (official)"; ?> 
                 </option><?php
                 endforeach?> 
             </select>

--- a/tpl/admin-poedit.tpl.php
+++ b/tpl/admin-poedit.tpl.php
@@ -46,7 +46,9 @@ $modified or $pofiles[] = $path;
                     $url = LocoAdmin::edit_uri( $package, $_path );
                 ?> 
                 <option value="<?php Loco::h($url)?>" <?php $poname === $label and print('selected')?>>
-                    <?php Loco::h($label)?> 
+                    <?php Loco::h($label); 
+					if (strpos($_path, DIRECTORY_SEPARATOR . 'wp-content' . DIRECTORY_SEPARATOR . 'languages' . DIRECTORY_SEPARATOR ) !== false) echo " (override)";
+					else echo " (official)"; ?>  
                 </option><?php
                 endforeach?> 
             </select>


### PR DESCRIPTION
"override" could otherwise be "user" or any other meaningful label, same for "official". But at least this allows to know if the file being edited will be persisted or not.
A more generic alternative could be to show the full path following /wp-content/.
